### PR TITLE
Align schema tests with v2 YAML syntax

### DIFF
--- a/tests/test_schema_full.py
+++ b/tests/test_schema_full.py
@@ -5,116 +5,130 @@ from pydantic import ValidationError
 from baygon.schema import normalize_spec, Spec
 
 
-EXAMPLE_V1_A = """
-version: 1
-tests:
-  - name: Arguments check
-    tests:
-      - name: No errors if two arguments
-        args: [1, 2]
-        exit: 0
-      - name: Error if less than two arguments
-        args: [1]
-        exit: 1
-  - name: Stdout is the sum of arguments
-    args: [1, 2]
-    stdout: []
-  - name: Version on stderr
-    args: ["--version"]
-    stderr:
-      - regex: '\\b\\d\\.\\d\\.\\d\\b'
-      - contains: "Version"
-"""
+EXAMPLE_V1_A = "\n".join(
+    [
+        "version: 1",
+        "tests:",
+        "  - name: Arguments check",
+        "    tests:",
+        "      - name: No errors if two arguments",
+        "        args: [1, 2]",
+        "        exit: 0",
+        "      - name: Error if less than two arguments",
+        "        args: [1]",
+        "        exit: 1",
+        "  - name: Stdout is the sum of arguments",
+        "    args: [1, 2]",
+        "    stdout: []",
+        "  - name: Version on stderr",
+        "    args: [\"--version\"]",
+        "    stderr:",
+        "      - match: 'm/\\d+\\.\\d+\\.\\d+/'",
+        "      - contains: \"Version\"",
+        "",
+    ]
+)
 
-EXAMPLE_V1_B = """
-version: 1
-filters:
-  ignorespaces: true
-tests:
-  - name: Stdout is the spaces are removed
-    args: [4, 5]
-    executable: add.exe.py
-    stdout:
-      - contains: "a+b=4+5"
-"""
+EXAMPLE_V1_B = "\n".join(
+    [
+        "version: 1",
+        "filters:",
+        "  - sub: 's/\\s+//g'",
+        "tests:",
+        "  - name: Stdout is the spaces are removed",
+        "    args: [4, 5]",
+        "    executable: add.exe.py",
+        "    stdout:",
+        "      - contains: \"a+b=4+5\"",
+        "",
+    ]
+)
 
-EXAMPLE_V1_C = """
-version: 1
-tests:
-  - name: Arguments check
-    tests:
-      - name: No errors if two arguments
-        args: [1]
-        exit: 0
-      - name: Error if less than two arguments
-        args: [1]
-        exit: 1
-  - name: Stdout is the sum of arguments
-    args: [1, 2]
-    stdout: [{ filters: { trim: true }, equals: 5 }]
-  - name: Version on stderr
-    args: ["--version"]
-    stderr:
-      - regex: '\\b\\d\\.\\d\\.\\d\\b'
-      - contains: "tarton"
-"""
+EXAMPLE_V1_C = "\n".join(
+    [
+        "version: 1",
+        "tests:",
+        "  - name: Arguments check",
+        "    tests:",
+        "      - name: No errors if two arguments",
+        "        args: [1]",
+        "        exit: 0",
+        "      - name: Error if less than two arguments",
+        "        args: [1]",
+        "        exit: 1",
+        "  - name: Stdout is the sum of arguments",
+        "    args: [1, 2]",
+        "    stdout:",
+        "      - trim: {}",
+        "      - equals: \"5\"",
+        "  - name: Version on stderr",
+        "    args: [\"--version\"]",
+        "    stderr:",
+        "      - match: 'm/\\d+\\.\\d+\\.\\d+/'",
+        "      - contains: \"tarton\"",
+        "",
+    ]
+)
 
 # V2: exercice complet de la syntaxe "moderne"
-EXAMPLE_V2_FULL = """
-version: 1
-exec:
-  cmd: ./a.out
-  timeout: 5
-  args: []
-  env: { }
-  shell: false
-filters:
-  - trim: {}
-  - sub: "s/\\\s+//g"
-tests:
-  - name: Arguments check
-    tests:
-      - name: No errors if two arguments
-        args: [1, 2]
-        exit: 0
-      - name: Error if less than two arguments
-        args: [1]
-        exit: 1
-  - name: Stdout is the sum of arguments
-    args: [1, 2]
-    stdout:
-      - match: "m/\\\b\\\d+\\\.\\\d+\\\.\\\d+\\\b/im"
-      - contains: "Version"
-      - sub: { regex: " ", repl: "", flags: "g" }
-      - equals: "3"
-      - capture:
-          regex: "(\\\d+)"
-          tests:
-            - lt: 10
-            - check_eval: "int(value) % 3 == 0"
-    stderr: []
-    files:
-      output.txt:
-        ops:
-          - trim: {}
-          - not_contains: "Error"
-  - name: Version on stderr
-    args: ["--version"]
-    stderr:
-      - match: "m/\\\b\\\d+\\\.\\\d+\\\.\\\d+\\\b/"
-      - contains: { value: "Version", explain: "Should mention Version" }
-  - name: With setup/teardown and stdin list
-    setup:
-      - run: echo pre
-      - eval: x = 1
-    teardown:
-      - run: echo post
-    stdin: ["line1", "line2"]
-    args: ["--echo-stdin"]
-    stdout:
-      - contains: "line1"
-      - contains: "line2"
-"""
+EXAMPLE_V2_FULL = "\n".join(
+    [
+        "version: 1",
+        "exec:",
+        "  cmd: ./a.out",
+        "  timeout: 5",
+        "  args: []",
+        "  env: { }",
+        "  shell: false",
+        "filters:",
+        "  - trim: {}",
+        "  - sub: 's/\\s+//g'",
+        "tests:",
+        "  - name: Arguments check",
+        "    tests:",
+        "      - name: No errors if two arguments",
+        "        args: [1, 2]",
+        "        exit: 0",
+        "      - name: Error if less than two arguments",
+        "        args: [1]",
+        "        exit: 1",
+        "  - name: Stdout is the sum of arguments",
+        "    args: [1, 2]",
+        "    stdout:",
+        "      - match: 'm/\\d+\\.\\d+\\.\\d+/im'",
+        "      - contains: \"Version\"",
+        "      - sub: { regex: \" \", repl: \"\", flags: \"g\" }",
+        "      - equals: \"3\"",
+        "      - capture:",
+        "          regex: '(\\d+)'",
+        "          tests:",
+        "            - lt: 10",
+        "            - check_eval: \"int(value) % 3 == 0\"",
+        "    stderr: []",
+        "    files:",
+        "      output.txt:",
+        "        ops:",
+        "          - trim: {}",
+        "          - not_contains: \"Error\"",
+        "  - name: Version on stderr",
+        "    args: [\"--version\"]",
+        "    stderr:",
+        "      - match: 'm/\\d+\\.\\d+\\.\\d+/'",
+        "      - contains: { value: \"Version\", explain: \"Should mention Version\" }",
+        "  - name: With setup/teardown and stdin list",
+        "    setup:",
+        "      - run: echo pre",
+        "      - eval: x = 1",
+        "    teardown:",
+        "      - run: echo post",
+        "    stdin: [\"line1\", \"line2\"]",
+        "    args: [\"--echo-stdin\"]",
+        "    stdout:",
+        "      - contains: \"line1\"",
+        "      - contains: \"line2\"",
+        "",
+    ]
+)
 
 
 def _ensure_exec(d: dict) -> dict:


### PR DESCRIPTION
## Summary
- update schema fixture examples to use Baygon v2-compatible filters and checks
- ensure complex stdout/capture scenarios rely on the canonical YAML forms

## Testing
- pytest tests/test_schema_full.py

------
https://chatgpt.com/codex/tasks/task_e_68dfd2b7da1c832b97d24196088ebe51