### PR TITLE
Add configuration loader with syntax error aggregation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ classifiers = [
 dependencies = [
   "pydantic>=2.7",
   "regex>=2024.5.15",
+  "PyYAML>=6.0",
 ]
 
 [project.optional-dependencies]

--- a/src/baygon/loader.py
+++ b/src/baygon/loader.py
@@ -1,0 +1,161 @@
+"""Chargement agnostique YAML/JSON avec gestion des erreurs de syntaxe.
+
+Ce module fournit une couche d'I/O minimale pour la DSL "baygon". Il
+permet de charger un texte ou un fichier et de le convertir en objet
+Python en essayant successivement les parseurs JSON et YAML. Les erreurs
+de syntaxe sont collectées pour qu'une CLI puisse les afficher de manière
+pédagogique.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+from yaml import YAMLError, safe_load
+
+Format = Literal["auto", "json", "yaml"]
+
+
+@dataclass(slots=True)
+class SyntaxIssue:
+    """Description d'une erreur de syntaxe détectée par un parseur."""
+
+    parser: Literal["json", "yaml"]
+    message: str
+    source: str | None = None
+    line: int | None = None
+    column: int | None = None
+    hint: str | None = None
+
+    def format_location(self) -> str:
+        source = self.source or "<string>"
+        if self.line is None:
+            return source
+        if self.column is None:
+            return f"{source}:{self.line}"
+        return f"{source}:{self.line}:{self.column}"
+
+    def to_message(self) -> str:
+        location = self.format_location()
+        if self.hint:
+            return f"[{self.parser}] {location}: {self.message} ({self.hint})"
+        return f"[{self.parser}] {location}: {self.message}"
+
+
+class ConfigSyntaxError(Exception):
+    """Erreur levée lorsque la configuration est invalide syntaxiquement."""
+
+    def __init__(self, issues: Iterable[SyntaxIssue]):
+        self.issues = list(issues)
+        if not self.issues:
+            raise ValueError("ConfigSyntaxError requiert au moins une erreur")
+        super().__init__("\n".join(issue.to_message() for issue in self.issues))
+
+
+def _format_json_issue(source: str | None, err: json.JSONDecodeError) -> SyntaxIssue:
+    hint = None
+    message = err.msg
+    if "Expecting property name" in err.msg:
+        hint = "Les clés JSON doivent être entourées de guillemets doubles"
+    return SyntaxIssue(
+        parser="json",
+        message=message,
+        source=source,
+        line=err.lineno,
+        column=err.colno,
+        hint=hint,
+    )
+
+
+def _format_yaml_issue(source: str | None, err: YAMLError) -> SyntaxIssue:
+    line: int | None = None
+    column: int | None = None
+    message = "Erreur YAML inconnue"
+    hint = None
+
+    mark = getattr(err, "problem_mark", None)
+    if mark is not None:
+        line = mark.line + 1
+        column = mark.column + 1
+
+    problem = getattr(err, "problem", None)
+    context = getattr(err, "context", None)
+
+    if problem and context:
+        message = str(problem)
+        hint = str(context)
+    elif problem:
+        message = str(problem)
+    else:
+        message = str(err).strip() or message
+
+    return SyntaxIssue(
+        parser="yaml",
+        message=message,
+        source=source,
+        line=line,
+        column=column,
+        hint=hint,
+    )
+
+
+def load_text(text: str, *, source: str | None = None, format: Format = "auto") -> Any:
+    """Charge un texte JSON ou YAML.
+
+    Parameters
+    ----------
+    text:
+        Contenu de la configuration.
+    source:
+        Nom de fichier ou identifiant du flux, uniquement utilisé pour les
+        messages d'erreur.
+    format:
+        "json", "yaml" ou "auto" pour essayer les deux.
+    """
+
+    errors: list[SyntaxIssue] = []
+
+    def _should_try(fmt: Format, target: Literal["json", "yaml"]) -> bool:
+        return fmt == target or fmt == "auto"
+
+    if _should_try(format, "json"):
+        try:
+            return json.loads(text)
+        except json.JSONDecodeError as exc:  # pragma: no cover - info branch
+            errors.append(_format_json_issue(source, exc))
+            if format == "json":
+                raise ConfigSyntaxError(errors) from exc
+
+    if _should_try(format, "yaml"):
+        try:
+            return safe_load(text)
+        except YAMLError as exc:
+            errors.append(_format_yaml_issue(source, exc))
+
+    if errors:
+        raise ConfigSyntaxError(errors)
+
+    raise ValueError(f"Format inconnu: {format}")
+
+
+def load_file(path: str | Path, *, format: Format = "auto", encoding: str = "utf-8") -> Any:
+    """Charge une configuration depuis un fichier."""
+
+    path = Path(path)
+    if format == "auto":
+        suffix = path.suffix.lower()
+        if suffix == ".json":
+            format = "json"
+        elif suffix in {".yml", ".yaml"}:
+            format = "yaml"
+
+    text = path.read_text(encoding=encoding)
+    return load_text(text, source=str(path), format=format)
+
+
+__all__ = ["ConfigSyntaxError", "SyntaxIssue", "load_file", "load_text"]
+

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import pytest
+
+from baygon.loader import ConfigSyntaxError, SyntaxIssue, load_file, load_text
+
+
+def test_load_text_json():
+    data = load_text('{"name": 1}', format="json", source="inline.json")
+    assert data == {"name": 1}
+
+
+def test_load_text_yaml():
+    yaml_text = """
+    steps:
+      - run: echo "hello"
+    """
+    data = load_text(yaml_text, format="yaml", source="inline.yaml")
+    assert data == {"steps": [{"run": 'echo "hello"'}]}
+
+
+def test_load_file_detects_format(tmp_path):
+    path = tmp_path / "config.json"
+    path.write_text('{"answer": 42}', encoding="utf-8")
+    assert load_file(path) == {"answer": 42}
+
+
+def test_json_error_contains_location():
+    with pytest.raises(ConfigSyntaxError) as excinfo:
+        load_text("{foo: 1}", format="json", source="broken.json")
+
+    (issue,) = excinfo.value.issues
+    assert issue.parser == "json"
+    assert issue.source == "broken.json"
+    assert issue.line == 1
+    assert issue.column is not None
+    assert "guillemets" in (issue.hint or "")
+
+
+def test_auto_collects_all_errors():
+    bad_text = "steps: [\n  - run: echo\n"
+    with pytest.raises(ConfigSyntaxError) as excinfo:
+        load_text(bad_text, source="broken.yml")
+
+    parsers = {issue.parser for issue in excinfo.value.issues}
+    assert parsers == {"json", "yaml"}
+    assert all(issue.source == "broken.yml" for issue in excinfo.value.issues)
+
+
+def test_invalid_format_raises_value_error():
+    with pytest.raises(ValueError):
+        load_text("{}", format="toml")  # type: ignore[arg-type]
+
+
+def test_syntax_issue_formatting_variants():
+    issue = SyntaxIssue(parser="yaml", message="Erreur")
+    assert issue.format_location() == "<string>"
+    assert issue.to_message() == "[yaml] <string>: Erreur"
+
+    issue_with_line = SyntaxIssue(parser="json", message="Oops", source="cfg", line=2)
+    assert issue_with_line.format_location() == "cfg:2"
+
+


### PR DESCRIPTION
## Summary
- add a loader module that parses JSON or YAML configurations and reports aggregated syntax issues
- expose syntax issue metadata for future CLI display and auto-detect file formats when reading from disk
- declare the PyYAML dependency and add unit tests covering the loader behaviour

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68dfd70fef10832b9d85699e4feffd07