### PR TITLE
Translate comments and error messages to English

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,8 +28,8 @@ classifiers = [
   "Programming Language :: Python :: 3.13",
   "Topic :: Software Development :: Testing",
 ]
-# Dépendances minimales pour schema.py
-# (on ajoute le reste quand on implémente le runner/CLI)
+# Minimal dependencies for schema.py
+# (the rest will be added when the runner/CLI is implemented)
 dependencies = [
   "pydantic>=2.7",
   "regex>=2024.5.15",
@@ -37,14 +37,14 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-# Dépendances pour développer et lancer les tests unitaires
-# Utiliser: `pip install -e .[dev]` ou `uv pip install -e .[dev]`
+# Dependencies used to develop and run the unit tests
+# Use: `pip install -e .[dev]` or `uv pip install -e .[dev]`
 dev = [
   "pytest>=8.3",
   "pytest-cov>=5.0",
   "ruff>=0.6",
 ]
-# Dépendances pour construire la documentation
+# Dependencies to build the documentation
 docs = [
   "mkdocs>=1.6,<2.0",
   "mkdocs-material[imaging]>=9.5,<10.0",
@@ -56,12 +56,12 @@ Documentation = "https://heig-tin-info.github.io/baygon/"
 Source = "https://github.com/heig-tin-info/baygon"
 Issues = "https://github.com/heig-tin-info/baygon/issues"
 
-# Entrées console (désactivées tant que la CLI n'est pas prête)
+# Console entry points (disabled until the CLI is ready)
 #[project.scripts]
 #baygon = "baygon.cli:main"
 
 [tool.hatch.build]
-# layout en src/
+# src/ layout
 include = ["src/baygon", "README.md", "LICENSE", "tests"]
 
 [tool.hatch.build.targets.wheel]
@@ -70,7 +70,7 @@ packages = ["src/baygon"]
 [tool.ruff]
 line-length = 100
 target-version = "py310"
-# active aussi le formateur intégré (évite Black)
+# Also enable the integrated formatter (avoids Black)
 
 [tool.ruff.lint]
 extend-select = ["I"]
@@ -83,7 +83,7 @@ select = [
   "RUF",            # ruff-specific
 ]
 ignore = [
-  "E501",   # line too long (laissé au formateur)
+  "E501",   # line too long (left to the formatter)
 ]
 
 [tool.pytest.ini_options]
@@ -103,7 +103,7 @@ source = ["baygon"]
 show_missing = true
 skip_covered = false
 
-# Support uv (optionnel) : déclarer des extras installables via `uv pip`
+# Optional uv support: declare extras installable via `uv pip`
 [tool.uv]
 
 [dependency-groups]
@@ -113,4 +113,4 @@ dev = [
     "mkdocs-material>=9.6.21",
     "pillow>=11.3.0",
 ]
-# rien d'obligatoire ici; uv lit les deps PEP 621
+# Nothing mandatory here; uv reads the PEP 621 dependencies

--- a/src/baygon/merge.py
+++ b/src/baygon/merge.py
@@ -1,4 +1,4 @@
-"""Propagation utilitaire des champs héritables d'un ``Spec``."""
+"""Utility propagation of inheritable ``Spec`` fields."""
 
 from __future__ import annotations
 
@@ -12,7 +12,7 @@ from .schema import TESTCASE_PROPAGATION, FileSpec, Spec, TestCase
 
 
 def _clone_items(items: list[Any]) -> list[Any]:
-    """Retourne une liste clonée (``model_copy`` pour les objets Pydantic)."""
+    """Return a cloned list (``model_copy`` for Pydantic models)."""
 
     cloned: list[Any] = []
     for item in items:
@@ -27,7 +27,7 @@ def _merge_files(
     parent: dict[str, FileSpec],
     child: dict[str, FileSpec],
 ) -> dict[str, FileSpec]:
-    """Fusionne les attentes sur les fichiers en préservant l'ordre parent → enfant."""
+    """Merge file expectations while preserving parent → child order."""
 
     merged: dict[str, FileSpec] = {
         name: spec.model_copy(deep=True) for name, spec in parent.items()
@@ -62,7 +62,7 @@ _missing = _expected - _initial_keys
 _extra = _initial_keys - _expected
 if _missing or _extra:  # pragma: no cover - configuration guard
     raise RuntimeError(
-        "Configuration de propagation incohérente",
+        "Inconsistent propagation configuration",
         {"missing": sorted(_missing), "extra": sorted(_extra)},
     )
 
@@ -84,7 +84,7 @@ def _combine_field(mode: str, parent: Any, child: Any) -> Any:
         merged: dict[str, int] = dict(parent or {})
         merged.update(child)
         return merged
-    raise ValueError(f"Mode de propagation inconnu: {mode}")
+    raise ValueError(f"Unknown propagation mode: {mode}")
 
 
 def _assign_field(mode: str, meta: dict[str, Any], value: Any) -> Any:
@@ -137,7 +137,7 @@ def _propagate(test: TestCase, ctx: dict[str, Any]) -> None:
 
 
 def merge_spec(spec: Spec) -> Spec:
-    """Retourne une copie de ``spec`` avec propagation des champs héritables."""
+    """Return a copy of ``spec`` with inheritable fields propagated."""
 
     merged = spec.model_copy(deep=True)
 

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -34,7 +34,7 @@ def test_json_error_contains_location():
     assert issue.source == "broken.json"
     assert issue.line == 1
     assert issue.column is not None
-    assert "guillemets" in (issue.hint or "")
+    assert "double quotes" in (issue.hint or "")
 
 
 def test_auto_collects_all_errors():
@@ -53,9 +53,9 @@ def test_invalid_format_raises_value_error():
 
 
 def test_syntax_issue_formatting_variants():
-    issue = SyntaxIssue(parser="yaml", message="Erreur")
+    issue = SyntaxIssue(parser="yaml", message="Error")
     assert issue.format_location() == "<string>"
-    assert issue.to_message() == "[yaml] <string>: Erreur"
+    assert issue.to_message() == "[yaml] <string>: Error"
 
     issue_with_line = SyntaxIssue(parser="json", message="Oops", source="cfg", line=2)
     assert issue_with_line.format_location() == "cfg:2"

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -61,7 +61,7 @@ def test_filters_compact_and_canonical_on_root():
     spec = normalize_spec(data)
     kinds = [op.kind for op in spec.filters]
     assert kinds == ["trim", "sub", "sub", "lower", "upper", "map_eval"]
-    # vérifie la normalisation du sub perl-like
+    # Ensure the perl-like sub expression is normalized
     fsub = spec.filters[1]
     assert fsub.regex == "\\s+" and fsub.repl == "" and "g" in (fsub.flags or "")
 
@@ -77,7 +77,7 @@ def test_checks_compact_vs_canonical_and_numbers():
                     {
                         "contains": {
                             "value": "Build",
-                            "explain": "doit mentionner Build",
+                            "explain": "must mention Build",
                         }
                     },
                     {"equals": 42},
@@ -232,7 +232,7 @@ def test_unknown_filter_error():
     }
     with pytest.raises(ValidationError) as ei:
         normalize_spec(data)
-    assert "Filtre inconnu" in str(ei.value)
+    assert "Unknown filter" in str(ei.value)
 
 
 def test_unknown_check_error():
@@ -244,7 +244,7 @@ def test_unknown_check_error():
     }
     with pytest.raises(ValidationError) as ei:
         normalize_spec(data)
-    assert "Check inconnu" in str(ei.value)
+    assert "Unknown check" in str(ei.value)
 
 
 def test_stream_item_must_be_single_key_object():
@@ -254,14 +254,14 @@ def test_stream_item_must_be_single_key_object():
             {
                 "name": "t",
                 "stdout": [
-                    {"contains": "A", "equals": "B"},  # deux clés -> erreur
+                    {"contains": "A", "equals": "B"},  # two keys -> error
                 ],
             },
         ],
     }
     with pytest.raises(ValidationError) as ei:
         normalize_spec(data)
-    assert "une seule clé" in str(ei.value)
+    assert "single-key" in str(ei.value)
 
 
 def test_files_wrong_shape():

--- a/tests/test_schema_full.py
+++ b/tests/test_schema_full.py
@@ -144,7 +144,7 @@ def test_yaml_v1_examples_parse(raw):
     data = _ensure_exec(data)
     spec = normalize_spec(data)
     assert isinstance(spec, Spec)
-    # Quelques assertions de surface
+    # A few surface-level assertions
     assert spec.version == 1
     assert spec.exec is not None
     assert spec.tests and len(spec.tests) >= 1
@@ -152,9 +152,9 @@ def test_yaml_v1_examples_parse(raw):
 
 def test_yaml_v2_full_parses():
     data = yaml.safe_load(EXAMPLE_V2_FULL)
-    spec = normalize_spec(data)  # a un bloc exec complet
+    spec = normalize_spec(data)  # has a full exec block
     assert isinstance(spec, Spec)
-    # On s'assure que quelques éléments ont bien été normalisés
+    # Ensure a couple of elements were normalized
     assert spec.filters and spec.filters[0].kind == "trim"
     suite = spec.tests[1]  # "Stdout is the sum of arguments"
     kinds = [op.kind for op in suite.stdout]


### PR DESCRIPTION
## Summary
- translate baygon core modules to use English comments, docstrings, and error messages
- update project configuration comments and unit tests to align with the English messaging

## Testing
- uv run pytest *(fails: baygon package and dependencies such as pydantic/yaml are not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3b0502524832bab6587385042dd59