### PR TITLE
Add Typer-based CLI with configuration validation command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,8 @@ dependencies = [
   "pydantic>=2.7",
   "regex>=2024.5.15",
   "PyYAML>=6.0",
+  "rich>=13.0",
+  "typer>=0.12",
 ]
 
 [project.optional-dependencies]
@@ -56,9 +58,8 @@ Documentation = "https://heig-tin-info.github.io/baygon/"
 Source = "https://github.com/heig-tin-info/baygon"
 Issues = "https://github.com/heig-tin-info/baygon/issues"
 
-# Console entry points (disabled until the CLI is ready)
-#[project.scripts]
-#baygon = "baygon.cli:main"
+[project.scripts]
+baygon = "baygon.cli:run"
 
 [tool.hatch.build]
 # src/ layout

--- a/src/baygon/__init__.py
+++ b/src/baygon/__init__.py
@@ -2,6 +2,14 @@
 
 from __future__ import annotations
 
+from importlib import metadata
+
 from .filters import add_filter, get_filter, iter_filters, registry
 
-__all__ = ["add_filter", "get_filter", "iter_filters", "registry"]
+try:
+    __version__ = metadata.version("baygon")
+except metadata.PackageNotFoundError:  # pragma: no cover - used in editable installs
+    __version__ = "0.0.0"
+
+__all__ = ["__version__", "add_filter", "get_filter", "iter_filters", "registry"]
+

--- a/src/baygon/cli.py
+++ b/src/baygon/cli.py
@@ -1,0 +1,114 @@
+"""Command line interface for Baygon."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+
+import typer
+from rich.console import Console
+
+from . import __version__
+from .loader import ConfigSyntaxError, SyntaxIssue, load_file
+
+console = Console()
+err_console = Console(stderr=True)
+
+
+@dataclass(slots=True)
+class CLIState:
+    """Runtime configuration shared across commands."""
+
+    verbosity: int = 0
+
+
+app = typer.Typer(add_completion=False, help="Utilities to inspect Baygon configuration files.")
+
+
+def _version_callback(value: bool) -> None:
+    if value:
+        console.print(__version__)
+        raise typer.Exit()
+
+
+def _configure_logging(verbosity: int) -> None:
+    level = logging.WARNING
+    if verbosity == 1:
+        level = logging.INFO
+    elif verbosity >= 2:
+        level = logging.DEBUG
+
+    logging.basicConfig(level=level, format="%(message)s", force=True)
+
+
+@app.callback()
+def main(
+    ctx: typer.Context,
+    verbose: int = typer.Option(
+        0,
+        "-v",
+        "--verbose",
+        count=True,
+        help="Increase verbosity. Repeat up to three times for more detail.",
+    ),
+    version: bool = typer.Option(
+        False, "--version", help="Show the Baygon version and exit.", callback=_version_callback, is_eager=True
+    ),
+) -> None:
+    """Configure the CLI before dispatching to a sub-command."""
+
+    _ = version  # Typer passes the processed value, but it is handled eagerly by the callback.
+
+    ctx.obj = CLIState(verbosity=verbose)
+    _configure_logging(verbose)
+
+
+def _render_issue(issue: SyntaxIssue) -> str:
+    location = issue.format_location()
+    hint = f" ({issue.hint})" if issue.hint else ""
+    return f"[{issue.parser}] {location}: {issue.message}{hint}"
+
+
+@app.command()
+def check(
+    ctx: typer.Context,
+    config: Path = typer.Argument(..., help="Path to the Baygon configuration file to validate."),
+) -> None:
+    """Validate a configuration file without executing it."""
+
+    state = ctx.obj or CLIState()
+    logger = logging.getLogger(__name__)
+    logger.debug("Checking configuration file %s", config)
+
+    try:
+        data = load_file(config)
+    except FileNotFoundError as exc:
+        err_console.print(f"[red]Error:[/] Could not read '{config}': {exc.strerror or exc}")
+        raise typer.Exit(code=1)
+    except ConfigSyntaxError as exc:
+        err_console.print(f"[red]Syntax error(s) detected in '{config}':[/]")
+        for issue in exc.issues:
+            err_console.print(f"  - {_render_issue(issue)}", markup=False)
+        raise typer.Exit(code=1)
+
+    logger.debug("Configuration loaded successfully: %s", data)
+    if state.verbosity >= 2:
+        console.print(data)
+    console.print("[green]Configuration looks good![/]")
+
+
+def run() -> None:
+    """Execute the Typer application."""
+
+    app()
+
+
+def main_cli() -> None:  # pragma: no cover - compatibility entry-point
+    """Backward compatible entry point used by packaging tools."""
+
+    run()
+
+
+__all__ = ["app", "run", "main_cli"]
+

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,44 @@
+"""Tests for the Baygon CLI."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from baygon.cli import app
+
+runner = CliRunner()
+
+
+def write_file(path: Path, content: str) -> Path:
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def test_check_valid_file(tmp_path: Path) -> None:
+    config = write_file(tmp_path / "good.yml", "name: Baygon\n")
+
+    result = runner.invoke(app, ["check", str(config)])
+
+    assert result.exit_code == 0
+    assert "Configuration looks good" in result.stdout
+
+
+def test_check_invalid_file(tmp_path: Path) -> None:
+    config = write_file(tmp_path / "bad.yml", "items: [1, 2\n")
+
+    result = runner.invoke(app, ["check", str(config)])
+
+    assert result.exit_code == 1
+    assert "Syntax error" in result.stderr
+    assert "[yaml]" in result.stderr
+
+
+def test_check_missing_file(tmp_path: Path) -> None:
+    config = tmp_path / "missing.yml"
+
+    result = runner.invoke(app, ["check", str(config)])
+
+    assert result.exit_code == 1
+    assert "Could not read" in result.stderr


### PR DESCRIPTION
## Summary
- add a Typer-based CLI entry point with verbosity, version option, and a `check` command
- report configuration syntax issues using Rich styling and register a console script
- cover the new CLI behaviour with unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e3ba494e60832b97fcc4f59c4e6958