### PR TITLE
Add automatic configuration discovery to loader and CLI

### DIFF
--- a/src/baygon/loader.py
+++ b/src/baygon/loader.py
@@ -9,14 +9,18 @@ display them in a user-friendly way.
 from __future__ import annotations
 
 import json
+import errno
 from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Iterator, Literal
 
 from yaml import YAMLError, safe_load
 
 Format = Literal["auto", "json", "yaml"]
+
+_SEARCH_PREFIXES: tuple[str, ...] = ("baygon", "test", "tests")
+_SEARCH_EXTENSIONS: tuple[str, ...] = (".yaml", ".yml", ".json")
 
 
 @dataclass(slots=True)
@@ -53,6 +57,97 @@ class ConfigSyntaxError(Exception):
         if not self.issues:
             raise ValueError("ConfigSyntaxError requires at least one error")
         super().__init__("\n".join(issue.to_message() for issue in self.issues))
+
+
+def _iter_search_directories(start: Path) -> Iterator[Path]:
+    current = start
+    while True:
+        yield current
+        if (current / ".git").exists():
+            break
+        parent = current.parent
+        if parent == current:
+            break
+        current = parent
+
+
+def _format_not_found(message: str, *, filename: str | None = None) -> FileNotFoundError:
+    return FileNotFoundError(errno.ENOENT, message, filename)
+
+
+def locate_config_file(
+    name: str | Path | None = None, *, start_dir: Path | None = None
+) -> Path:
+    """Locate a configuration file following Baygon's discovery rules.
+
+    The search honours the following rules:
+
+    1. Candidate files must end with ``.yaml``, ``.yml`` or ``.json``.
+    2. File names starting with ``baygon`` are preferred, then ``test`` and
+       finally ``tests``.
+    3. Lookup starts from ``start_dir`` (or ``Path.cwd()`` when omitted) and
+       walks up the directory tree until the filesystem root or the first
+       directory containing a ``.git`` entry.
+
+    Parameters
+    ----------
+    name:
+        Optional explicit file to locate. It can be a file name or a path. When
+        omitted the discovery rules above are used.
+    start_dir:
+        Directory where the search starts. Defaults to the current working
+        directory.
+    """
+
+    start_dir = (start_dir or Path.cwd()).resolve()
+
+    candidate: Path | None = None
+    target_name: str | None = None
+
+    if name is not None:
+        candidate = Path(name)
+        if candidate.is_absolute():
+            if candidate.is_file():
+                return candidate
+            message = f"Could not find configuration file '{candidate}'."
+            raise _format_not_found(message, filename=str(candidate))
+
+        candidate_in_start = (start_dir / candidate).resolve()
+        if candidate_in_start.is_file():
+            return candidate_in_start
+
+        if candidate.parts and len(candidate.parts) > 1:
+            message = f"Could not find configuration file '{candidate}'."
+            raise _format_not_found(message, filename=str(candidate))
+
+        target_name = candidate.name
+
+    search_directories = tuple(_iter_search_directories(start_dir))
+
+    if target_name:
+        for directory in search_directories:
+            potential = directory / target_name
+            if potential.is_file():
+                return potential
+            if Path(target_name).suffix:
+                continue
+            for extension in _SEARCH_EXTENSIONS:
+                potential_with_ext = directory / f"{target_name}{extension}"
+                if potential_with_ext.is_file():
+                    return potential_with_ext
+
+    for directory in search_directories:
+        for prefix in _SEARCH_PREFIXES:
+            for extension in _SEARCH_EXTENSIONS:
+                for path in sorted(directory.glob(f"{prefix}*{extension}")):
+                    if path.is_file():
+                        return path
+
+    if name is None:
+        message = f"Could not locate a configuration file starting from '{start_dir}'."
+    else:
+        message = f"Could not find configuration file '{name}'."
+    raise _format_not_found(message, filename=str(name) if name else None)
 
 
 def _format_json_issue(source: str | None, err: json.JSONDecodeError) -> SyntaxIssue:
@@ -141,20 +236,25 @@ def load_text(text: str, *, source: str | None = None, format: Format = "auto") 
 
 
 def load_file(
-    path: str | Path, *, format: Format = "auto", encoding: str = "utf-8"
+    path: str | Path | None = None,
+    *,
+    format: Format = "auto",
+    encoding: str = "utf-8",
+    start_dir: Path | None = None,
 ) -> Any:
     """Load a configuration from a file."""
 
-    path = Path(path)
+    resolved_path = locate_config_file(path, start_dir=start_dir)
+
     if format == "auto":
-        suffix = path.suffix.lower()
+        suffix = resolved_path.suffix.lower()
         if suffix == ".json":
             format = "json"
         elif suffix in {".yml", ".yaml"}:
             format = "yaml"
 
-    text = path.read_text(encoding=encoding)
-    return load_text(text, source=str(path), format=format)
+    text = resolved_path.read_text(encoding=encoding)
+    return load_text(text, source=str(resolved_path), format=format)
 
 
-__all__ = ["ConfigSyntaxError", "SyntaxIssue", "load_file", "load_text"]
+__all__ = ["ConfigSyntaxError", "SyntaxIssue", "load_file", "load_text", "locate_config_file"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -42,3 +42,22 @@ def test_check_missing_file(tmp_path: Path) -> None:
 
     assert result.exit_code == 1
     assert "Could not read" in result.stderr
+
+
+def test_check_auto_discovers_file() -> None:
+    with runner.isolated_filesystem():
+        config = Path("baygon.yaml")
+        config.write_text("name: Baygon\n", encoding="utf-8")
+
+        result = runner.invoke(app, ["check"])
+
+        assert result.exit_code == 0
+        assert "Configuration looks good" in result.stdout
+
+
+def test_check_auto_reports_missing() -> None:
+    with runner.isolated_filesystem():
+        result = runner.invoke(app, ["check"])
+
+        assert result.exit_code == 1
+        assert "Could not read" in result.stderr


### PR DESCRIPTION
## Summary
- add a configuration discovery helper that searches for baygon/test files and respects git roots
- update the loader and CLI to use automatic discovery and allow optional config arguments
- extend loader and CLI tests to cover discovery behaviours and CLI auto-detection

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e40eeb8490832b85180ca1bc70a84d